### PR TITLE
Don't check this.props.loading when transferring

### DIFF
--- a/src/components/organisms/transfer/send/passwordSteps/passwordSteps.js
+++ b/src/components/organisms/transfer/send/passwordSteps/passwordSteps.js
@@ -177,9 +177,7 @@ class PasswordSteps extends React.Component {
                 />
                 <PrimaryButton
                   disabled={
-                    !this.state.password.value ||
-                    (this.props.loading && this.props.loading.length > 0) ||
-                    this.state.sent
+                    !this.state.password.value || this.state.sent
                   }
                   label={t('Next')}
                   onClick={() => this.handleClick()} />


### PR DESCRIPTION
Many users from other continents are struggling with the following issue that the `Send` button is disabled even though they typed their password correctly:
![image](https://user-images.githubusercontent.com/5462944/109766447-861d9d80-7c39-11eb-9f7e-391bf61f23ae.png)
(This screenshot is from a user in Canada.)

By inspecting source codes, I found the following piece of codes and guessed that `this.props.loading` is `false`.
```js
<PrimaryButton
  disabled={
    !this.state.password.value ||
    (this.props.loading && this.props.loading.length > 0) ||
    this.state.sent
  }
  label={t('Next')}
  onClick={() => this.handleClick()} />
```
Previously, I found that the SSL certificate of `https://explorer-server.medibloc.org` had been expired. That was why `this.props.loading` was false. So, it was easy to fix.

However, it occurred again recently even though all SSL certificates are live.

I've tried to reproduce it by running VNC on AWS EC2 in the Canada region, but failed to reproduce (VNC has been downed continously).

So, I made this experimental PR that remove checking `this.props.loading`. 
Due to the lack of my React knowledge, I wasn't able to find where `this.props.loading` is set/unset. But, I guess it's not that necessary for executing a Panacea transaction.

Sadly, I couldn't test this PR in Canada because of pool VNC performance. Thus, I don't want to merge this PR irresponsibly. I just want to ask your opinion whether this fix is reasonable or not, in common senses. If so, I will try again to reproduce this issue and test this change.