### PR TITLE
fix: Typo in networks.js

### DIFF
--- a/config/networks.js
+++ b/config/networks.js
@@ -4,7 +4,7 @@ const networks = {
     chainId: 'panacea-1',
     code: 0,
     mServerURL: 'https://explorer-server.medibloc.org',
-    mClientURL: 'https://explroer.medibloc.org',
+    mClientURL: 'https://explorer.medibloc.org',
     nodes: ['https://wallet-lcd.gopanacea.org'],
   },
   testnet: { // network name translation t('Testnet');


### PR DESCRIPTION
This typo is so harmful in production, but it seems our https://wallet.gopanacea.org was deployed by fixing this typo without committing it to GitHub.