### PR TITLE
docs: Update README for better build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Then, the dev server can be run:
 npm run dev
 ```
 
+
+## Deploying
+
 ### Packaging for production
 
 ```bash
@@ -58,7 +61,10 @@ For other networks, see the `build:testnet` script in the [package.json](https:/
 This process would be improved in near future.
 
 The package is built in the output directory: `app/build/`.
-Upload those files to the AWS S3 bucket which is associated to a proper AWS Cloudfront.
+
+### Uploading the package to AWS S3
+
+Upload the package to the AWS S3 bucket which is associated to a proper AWS Cloudfront.
 ```bash
 cd app/build/
 aws cp . s3://BUCKET_NAME/ --recursive

--- a/README.md
+++ b/README.md
@@ -1,66 +1,67 @@
-# MediBloc Wallet
+# Panacea Web Wallet
 
-Official wallet for the [medibloc blockchain](https://github.com/medibloc/go-medibloc). Desktop version will be published soon.
+An official web wallet for [Panacea](https://github.com/medibloc/panacea).
+
+## Building
 
 ### Prerequisites
 
-To run MediBloc Wallet following resources are required.
+- Node.js v10.13.0 ~ v10.24.0
+- [Panacea LCD(Light Client Daemon)](https://medibloc.gitbook.io/panacea-core/guide/light-client-daemon)
+  - or, the pre-deployed LCD can be used. See below.
+- [Panacea Explorer Server](https://github.com/medibloc/explorer)
+  - or, the pre-deployed Explorer Server can be used. See below.
+  
+### Installing dependencies
 
-- Node.js v10.13.0 or higher (<https://nodejs.org/>)
-
-- NPM v6.4.1 or higher (<https://www.npmjs.com/>)
-
-- go-medibloc v1.0 (<https://github.com/medibloc/go-medibloc>) - You need to install all required resources written in [go-medibloc](https://github.com/medibloc/go-medibloc).
-
-  ```
-  git clone https://github.com/medibloc/go-medibloc.git
-  cd go-medibloc
-  make dep
-  make build
-  build/medi conf/local/single_node/node.conf
-  ```
-
-- MediBloc Explorer v1.0 (<https://github.com/medibloc/explorer>) - You need to install a server required resources written in [explorer](https://github.com/medibloc/explorer).
-
-## Installation
-
-- Clone the MediBloc Wallet repository and install npm modules.
-
-  ```
-  git clone https://github.com/medibloc/wallet.git
-  cd wallet
-  npm install
-  ```
-
-## Running a server using webpack-dev-server
-### Configuration
-
-* [networks.js](https://github.com/medibloc/wallet/blob/master/config/networks.js) configuration
-
-You can add a new network configuration like below.
-
-```
-  ...
-  custom: { // key of the networks object
-    name: 'custom', // name of the network
-    chainId: 999999, // chain id of the blockchain
-    code: 999999, // code of the network
-    mServerURL: 'http://localhost:3001', // MediBloc Explorer Server endpoint,
-    nodes: ['http://localhost:9921'], // Blockchain RPC endpoint array
-  },
-  ...
-```
-* .env file
-
-You should create .env file in the root directory and set CHAIN_VERSION to the networks object key like below.
-
-```
-CHAIN_VERSION=custom
+```bash
+npm install
 ```
 
-### Running
+### Running a dev server
+
+First of all, edit configurations in the [networks.js](https://github.com/medibloc/wallet/blob/master/config/networks.js).
+There are two pre-defined network configurations for each of Mainnet and Testnet.
+Additional network configurations can be defined as below.
+```ts
+{
+  ...,
+  mynet: {
+    name: 'Mynet',                        // An alias of the network
+    chainId: 'mychain-1',                 // A chain ID of the network
+    code: 2,                              // To be deprecated soon
+    mServerURL: 'http://localhost:8080',  // A Panacea Explorer Server endpoint
+    mClientURL: 'http://localhost:7070',  // A Panacea Explorer Client(web) endpoint
+    nodes: ['http://localhost:1317'],     // Panacea LCD endpoints
+  }
+}
 ```
-$ npm run dev
+
+Next, set an environment variable `CHAIN_VERSION`.
+It must be one of the network keys configured in the `networks.js` (such as `mainnet`, `testnet` or `mynet` from the example above).
+```bash
+export CHAIN_VERSION=mynet
+```
+
+Then, the dev server can be run:
+```bash
+npm run dev
+```
+
+### Packaging for production
+
+```bash
+npm run build
+```
+That command makes a package for Mainnet by default.
+For other networks, see the `build:testnet` script in the [package.json](https://github.com/medibloc/wallet/blob/master/config/networks.js) for now.
+This process would be improved in near future.
+
+The package is built in the output directory: `app/build/`.
+Upload those files to the AWS S3 bucket which is associated to a proper AWS Cloudfront.
+```bash
+cd app/build/
+aws cp . s3://BUCKET_NAME/ --recursive
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,8 @@ npm run dev
 ### Packaging for production
 
 ```bash
-npm run build
+CHAIN_VERSION=mainnet npm run build
 ```
-That command makes a package for Mainnet by default.
-For other networks, see the `build:testnet` script in the [package.json](https://github.com/medibloc/wallet/blob/master/config/networks.js) for now.
-This process would be improved in near future.
-
 The package is built in the output directory: `app/build/`.
 
 ### Uploading the package to AWS S3


### PR DESCRIPTION
The previous build instructions in README are too out-dated.